### PR TITLE
doc: python required 2.7+

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -864,7 +864,7 @@ To enable debuginfo in your LuaJIT build, pass the `CCDEBUG=-g` command-line arg
 
     make CCDEBUG=-g
 
-Also, you are required to use gdb 7.6+ with python support enabled.
+Also, you are required to use gdb 7.6+ with python 2.7+ support enabled.
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
I got this error mesage when I use python2.6, and works fine with python2.7

```
lgcpath 1000
path 000:[registry] ->Tab["_LOADED"] ->Tab Traceback (most recent call last):
  File "luajit21.py", line 2671, in invoke
    self.visit_tval(g['registrytv'], g)
  File "luajit21.py", line 2927, in visit_tval
    self.dfs(gcval(tv), g)
  File "luajit21.py", line 2908, in dfs
    self.visit_tab(obj['tab'].address, g)
  File "luajit21.py", line 2997, in visit_tab
    self.dfs(gcval(tv), g)
  File "luajit21.py", line 2902, in dfs
    self.print_obj_path(g)
  File "luajit21.py", line 2869, in print_obj_path
    out("sz:%d (GCobj*)%#x ->END\n" % (sz, gco))
  File "/home/admin/work/git/nginx-gdb-utils/gdbutils.py", line 44, in out
    stdout.write(str(s))
  File "/usr/lib64/python2.6/codecs.py", line 352, in write
    self.stream.write(data)
  File "/usr/local/share/gdb/python/gdb/__init__.py", line 48, in write
    write(s, stream=STDOUT)
gdb.error: Cannot convert value to int.

Error occurred in Python command: Cannot convert value to int.
```