### PR TITLE
feature: lval support GCudata and lgcpath support udata

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -614,7 +614,7 @@ lgcpath
 
 **file** *luajit21.py*
 
-Finds large live LuaJIT GC objects with the size threshold (in bytes) and a type name ("tab", "str", "tab", "thr", "upval", "func", "tr"). The type name argument is optional. Also prints out the full referencing path from the GC roots to the object being matched.
+Finds large live LuaJIT GC objects with the size threshold (in bytes) and a type name ("udata", "str", "tab", "thr", "upval", "func", "tr"). The type name argument is optional. Also prints out the full referencing path from the GC roots to the object being matched.
 
 For example, finds all the live Lua tables whose size has exceeded 100KB:
 


### PR DESCRIPTION
We can find out large user-data object by lgcpath
and we can dump the user-data by `lval (GCudata*)address_from_lgcpath` 

```
(gdb) lgcpath 10 udata
path 000:[registry] ->Tab["_LOADED"] ->Tab["coroutine"] ->Tab["wrap"] ->lfunc(=coroutine.wrap:19) ->upval[0] ->Tab["io"] ->Tab["stdin"] -> user-data sz:40 (GCobj*)0x40d3a0d0 ->END
path 001:[registry] ->Tab["_LOADED"] ->Tab["coroutine"] ->Tab["wrap"] ->lfunc(=coroutine.wrap:19) ->upval[0] ->Tab["io"] ->Tab["stdout"] -> user-data sz:40 (GCobj*)0x40d3a120 ->END
path 002:[registry] ->Tab["_LOADED"] ->Tab["coroutine"] ->Tab["wrap"] ->lfunc(=coroutine.wrap:19) ->upval[0] ->Tab["io"] ->Tab["stderr"] -> user-data sz:40 (GCobj*)0x40d3a170 ->END
path 003:[registry] ->Tab["_LOADED"] ->Tab["coroutine"] ->Tab["wrap"] ->lfunc(=coroutine.wrap:19) ->upval[0] ->Tab["math"] ->Tab["randomseed"] ->cfunc ->upval[0] -> user-data sz:64 (GCobj*)0x40d3ada0 ->END
path 004:[registry] ->Tab["_LOADED"] ->Tab["cjson"] ->Tab["encode_invalid_numbers"] ->cfunc ->upval[0] -> user-data sz:1376 (GCobj*)0x40d4c258 ->END
path 005:[registry] ->Tab["_LOADED"] ->Tab["ffi"] ->Tab["C"] -> user-data sz:40 (GCobj*)0x40d4fa40 ->END
path 006:[registry] ->Tab["LOADLIB: /usr/local/openresty/lualib/cjson.so"] -> user-data sz:32 (GCobj*)0x40d4bf38 ->END
path 007:[registry] ->Tab[tv=0x40d44120] ->Tab["10.1.81.97:6380"] -> user-data sz:17695 (GCobj*)0x4182f760 ->END
path 008:[registry] ->Tab[tv=0x40d44198] ->Tab[523] ->thr(ptr:0x40ac1c58) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x41828978 ->END
path 009:[registry] ->Tab[tv=0x40d44198] ->Tab[526] ->thr(ptr:0x416f7da0) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x416de458 ->END
path 010:[registry] ->Tab[tv=0x40d44198] ->Tab[555] ->thr(ptr:0x40143690) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x40143f50 ->END
path 011:[registry] ->Tab[tv=0x40d44198] ->Tab[602] ->thr(ptr:0x40856570) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x420049f8 ->END
path 012:[registry] ->Tab[tv=0x40d44198] ->Tab[604] ->thr(ptr:0x40bd0768) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x419b55b8 ->END
path 013:[registry] ->Tab[tv=0x40d44198] ->Tab[608] ->thr(ptr:0x40bdf6d0) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x4068aa48 ->END
path 014:[registry] ->Tab[tv=0x40d44198] ->Tab[609] ->thr(ptr:0x41707070) ->stack[16] ->Tab["sock"] ->Tab[1] -> user-data sz:440 (GCobj*)0x40441b18 ->END
... more paths ...
(gdb) lval (GCudata*)0x40d3a0d0
                udata type: io file
                      payload len: 16
                      payload ptr: 0x40d3a0e8
(gdb) lval (GCudata*)0x40d3ada0
                udata type: userdata
                      payload len: 40
                      payload ptr: 0x40d3adb8
                      payload header: "........................................"
```